### PR TITLE
Replace - with _ in resource name

### DIFF
--- a/postgresql/templates/database.yaml
+++ b/postgresql/templates/database.yaml
@@ -6,7 +6,7 @@
 apiVersion: dbforpostgresql.azure.com/v1api20210601
 kind: FlexibleServersDatabase
 metadata:
-  name: {{ $database.name }}
+  name: {{ $database.name | replace "_" "-" }}
   {{- ( include "hmcts.labels.v2" $base ) | indent 2 }}
 spec:
   owner:


### PR DESCRIPTION
```
Error: INSTALLATION FAILED: failed to create resource: FlexibleServersDatabase.dbforpostgresql.azure.com "cft_task_db" is invalid: metadata.name: Invalid value: "cft_task_db": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
##[error]Bash exited with code '1'.
Finishing: Helm Install
```